### PR TITLE
Added setting to open files either as preview or permanently

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,18 @@
           "type": "webview"
         }
       ]
-    }
-  },
+    },
+	"configuration": {
+		"title": "Search Files",
+		"properties": {
+			"file-searcher.openAsPreview": {
+				"type": "boolean",
+				"default": true,
+				"description": "Open files in preview mode."
+			}
+		}
+	}
+},
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",

--- a/src/FileSearchViewProvider.ts
+++ b/src/FileSearchViewProvider.ts
@@ -71,9 +71,14 @@ export class FileSearchViewProvider implements vscode.WebviewViewProvider {
                     }
                 case 'openFile':
                     {
+					    const config = vscode.workspace.getConfiguration("file-searcher");
+						const open_as_preview = config.get("openAsPreview", true);
                         const uri = vscode.Uri.parse(data.uri);
                         vscode.workspace.openTextDocument(uri).then(doc => {
-                            vscode.window.showTextDocument(doc);
+                            vscode.window.showTextDocument(doc, {
+								preview: open_as_preview,
+								preserveFocus: true
+							});
                         });
                         break;
                     }


### PR DESCRIPTION
When you click a file it opens as a preview by default. If you want to open several files in a quick succession you have to double click each tab. This PR allows to choose a setting for opening files permanently.

<img width="975" height="364" alt="image" src="https://github.com/user-attachments/assets/2f6e531f-d7c8-4c11-ae2c-f33678932ab7" />
<br>
<img width="1524" height="335" alt="image" src="https://github.com/user-attachments/assets/2143b07e-6645-423e-94e7-4cb9314e4988" />